### PR TITLE
Fix case sensitivity with vote names and add "mode" option

### DIFF
--- a/src/main/java/io/github/hsyyid/votifierlistener/VotifierListenerPlugin.java
+++ b/src/main/java/io/github/hsyyid/votifierlistener/VotifierListenerPlugin.java
@@ -195,11 +195,22 @@ public class VotifierListenerPlugin
 
 				uniqueAccount.deposit(economyService.getDefaultCurrency(), decimal, Cause.of(NamedCause.source(player)));
 
-				for (int counter = 0; counter < Utils.getAmtOfRewards(); counter++)
+				if (!Utils.shouldGiveAllRewards())
 				{
-					String command = Utils.getRewards().get(rand.nextInt(Utils.getRewards().size()));
-					command = command.replaceAll("@p", player.getName());
-					Sponge.getCommandManager().process(Sponge.getServer().getConsole(), command);
+
+					for (int counter = 0; counter < Utils.getAmtOfRewards(); counter++) {
+						String command = Utils.getRewards().get(rand.nextInt(Utils.getRewards().size()));
+						command = command.replaceAll("@p", player.getName());
+						Sponge.getCommandManager().process(Sponge.getServer().getConsole(), command);
+					}
+				}
+				else
+				{
+					for (int counter = 0; counter < Utils.getRewards().size(); counter++) {
+						String command = Utils.getRewards().get(counter);
+						command = command.replaceAll("@p", player.getName());
+						Sponge.getCommandManager().process(Sponge.getServer().getConsole(), command);
+					}
 				}
 
 				break;

--- a/src/main/java/io/github/hsyyid/votifierlistener/VotifierListenerPlugin.java
+++ b/src/main/java/io/github/hsyyid/votifierlistener/VotifierListenerPlugin.java
@@ -181,7 +181,7 @@ public class VotifierListenerPlugin
 
 		for (Player player : Sponge.getServer().getOnlinePlayers())
 		{
-			if (player.getName().equals(vote.getUsername()))
+			if (player.getName().equalsIgnoreCase(vote.getUsername()))
 			{
 				player.sendMessage(Text.of(TextColors.GREEN, "Thanks for Voting! Here is a reward!"));
 				UniqueAccount uniqueAccount = economyService.getOrCreateAccount(player.getUniqueId()).get();

--- a/src/main/java/io/github/hsyyid/votifierlistener/config/RewardsConfig.java
+++ b/src/main/java/io/github/hsyyid/votifierlistener/config/RewardsConfig.java
@@ -83,10 +83,11 @@ public class RewardsConfig implements Configurable
 	@Override
 	public void populate()
 	{
-		get().getNode("rewards", "amount").setValue(2).setComment("Number of rewards a player will receive.");
+		get().getNode("rewards", "amount").setValue(2).setComment("Number of random rewards a player will receive.");
 		get().getNode("rewards", "commands").setValue("minecraft:give @p minecraft:diamond_sword 1,").setComment("Possible reward commands for voting.");
 		get().getNode("rewards", "money", "maximum").setValue(500).setComment("Maximum amount of money a player can get for voting.");
 		get().getNode("rewards", "money", "minimum").setValue(100).setComment("Minimum amount of money a player can get for voting.");
+		get().getNode("rewards", "mode").setValue("random").setComment("Mode for giving rewards. Set to 'all' to give one of each, set to 'random' to give 'amount' number of random rewards.");
 	}
 
 	@Override

--- a/src/main/java/io/github/hsyyid/votifierlistener/utils/Utils.java
+++ b/src/main/java/io/github/hsyyid/votifierlistener/utils/Utils.java
@@ -176,12 +176,20 @@ public class Utils
 	{
 		ConfigurationNode valueNode = Configs.getConfig(rewardsConfig).getNode("rewards", "mode");
 
-		if (valueNode.getValue() != null)
-		{
+		if (valueNode.getValue() != null) {
 			if (valueNode.getValue().toString().equalsIgnoreCase("all"))
+			{
 				return true;
-			else
+			}
+			else if (valueNode.getValue().toString().equalsIgnoreCase("random"))
+			{
 				return false;
+			}
+			else
+			{
+				Configs.setValue(rewardsConfig, valueNode.getPath(), "random");
+				return false;
+			}
 		}
 		else
 		{

--- a/src/main/java/io/github/hsyyid/votifierlistener/utils/Utils.java
+++ b/src/main/java/io/github/hsyyid/votifierlistener/utils/Utils.java
@@ -161,7 +161,7 @@ public class Utils
 	{
 		ConfigurationNode valueNode = Configs.getConfig(rewardsConfig).getNode("rewards", "amount");
 		
-		if(valueNode.getValue() != null)
+		if (valueNode.getValue() != null)
 		{
 			return valueNode.getInt();
 		}
@@ -169,6 +169,24 @@ public class Utils
 		{
 			Configs.setValue(rewardsConfig, valueNode.getPath(), 2);
 			return 2;
+		}
+	}
+
+	public static boolean shouldGiveAllRewards()
+	{
+		ConfigurationNode valueNode = Configs.getConfig(rewardsConfig).getNode("rewards", "mode");
+
+		if (valueNode.getValue() != null)
+		{
+			if (valueNode.getValue().toString().equalsIgnoreCase("all"))
+				return true;
+			else
+				return false;
+		}
+		else
+		{
+			Configs.setValue(rewardsConfig, valueNode.getPath(), "random");
+			return false;
 		}
 	}
 


### PR DESCRIPTION
This fixes case sensitivity with player vote names and adds a "mode" option to the rewards config. The "mode" option defaults to "random", so no sudden unexpected behaviour will occur upon updating the plugin.
